### PR TITLE
docs/fix typo in documentation

### DIFF
--- a/docs/plugins/widget/Plugin_Tool.md
+++ b/docs/plugins/widget/Plugin_Tool.md
@@ -94,7 +94,7 @@ To generate plugin with random gid.
 ai-verify-plugin gp --name "My Plugin" --description "Just a test plugin"
 ```
 
-To genreate plugin with specific gid.
+To generate plugin with specific gid.
 ```
 ai-verify-plugin gp "myplugin" --name "My Plugin" --description "Just a test plugin"
 ```

--- a/docs/plugins/widget/Widget.md
+++ b/docs/plugins/widget/Widget.md
@@ -52,7 +52,7 @@ The **widgetSize** property defines the minimum and maximum size of the widget. 
 
 ### Widget Property Schema
 
-The widget properties allows widget developers to define properties that affects the look and/or behaviour of the widget. Example of properties are color, textual information, etc. Each property should have a default value that is used if the property has no input. The template designers can change the properties of a widget by right clicking the widget in the canvas page to bring up the propery dialog. Each property value can be a string input or selected from the canvas *Global Properties*.
+The widget properties allows widget developers to define properties that affects the look and/or behaviour of the widget. Example of properties are color, textual information, etc. Each property should have a default value that is used if the property has no input. The template designers can change the properties of a widget by right clicking the widget in the canvas page to bring up the property dialog. Each property value can be a string input or selected from the canvas *Global Properties*.
 
 | Propreties | Type | Required | Description |
 | ---------- | ---- | -------- | ----------- |


### PR DESCRIPTION
Attached is a screenshot of the typo. 

<img width="714" alt="Screenshot 2023-07-19 at 2 32 40 PM" src="https://github.com/IMDA-BTG/aiverify-developer-tools/assets/39306724/bae14697-300a-4f5b-b594-c40718988961">
