### PR TITLE
fix the nodemapper to add ai-verify-shared-lib

### DIFF
--- a/ai-verify-plugin/jest.config.mjs
+++ b/ai-verify-plugin/jest.config.mjs
@@ -18,6 +18,7 @@ const customConfig = {
     "src/(.*)": "<rootDir>/src/$1",
     "playground/(.*)": "<rootDir>/playground/$1",
     // "ai-verify-shared-library/(.*)": "<rootDir>/node_modules/ai-verify-shared-library/$1",
+    "ai-verify-shared-library/(.*)": "<rootDir>/node_modules/ai-verify-shared-library/packages/$1/src",
   },
   // moduleFileExtensions: ["mjs", "js", "jsx", "ts", "tsx"],
   testMatch: [
@@ -30,7 +31,6 @@ const customConfig = {
   globals: {
 		Uint8Array: Uint8Array,
 	},
-  
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
Fix issue where import of ai-verify-shared-library/lib in snapshot testing gives error "Cannot find module".

To Test:

1. Generate new plugin
2. Generate new widget and/or input block
3. Run test 'ai-verify-plugin test' and ensure that tests are run successfully.