### PR TITLE
Fix/playground/dataoutput

### DIFF
--- a/ai-verify-plugin/app/InputBlock/[cid]/displayInputBlock.tsx
+++ b/ai-verify-plugin/app/InputBlock/[cid]/displayInputBlock.tsx
@@ -79,9 +79,9 @@ export default function DisplayInputBlock ({inputBlock, pluginMeta, code, frontm
               onClick={() => setSelectedIndex(1)}
             >Data Output</Button>
           </div>
-          <div className='aiv-panel' style={{ backgroundColor:'white', marginTop:'5px', height:'100%', overflow:'hidden' }}>
+          <div className='aiv-panel' style={{ backgroundColor:'white', color:'#676767', marginTop:'5px', height:'100%', overflow:'hidden' }}>
             {selectedIndex==0 && <DisplayMetaInformation component={inputBlock} schema={inputBlockSchema} />}
-            {selectedIndex==1 && <pre style={{ padding:'10px', margin:'10px', height:'calc(100% - 20px)', overflowY:'auto' }}>{JSON.stringify(inputBlockContext.data, null, 2)}</pre>}
+            {selectedIndex==1 && <pre style={{ padding:'10px', margin:'10px', height:'calc(100% - 20px)', overflowY:'auto', textAlign:'left' }}>{JSON.stringify(inputBlockContext.data, null, 2)}</pre>}
           </div>
         </div>
       </div>

--- a/ai-verify-plugin/playground/components/displayMetaInformation.tsx
+++ b/ai-verify-plugin/playground/components/displayMetaInformation.tsx
@@ -32,6 +32,7 @@ const theme = createTheme({
 });
 
 const uiSchema: UiSchema = {
+  "ui:readonly": true,
   "ui:options": {
     "submitButtonOptions": {
       "norender": true,


### PR DESCRIPTION
The "DATA OUTPUT" of the input blocks displayed on the playground are not visible because the texts are white against a white background. It's also align to center which makes the text unreadable.

Fixes:
1) Fix the color and text alignment of the "DATA OUTPUT".
2) Update the inputs of the meta properties display to readonly.

To Test:
1) Run the playground on a plugin with input box forms, .e.g. process checklist plugin
2) Click on one of the input block and then select the right sidebar tab "DATA OUTPUT"
3) Start to fill in the form, the form data should be visible and display in the "DATA OUTPUT" tab.
4) Click on the meta properties tab and verify that the inputs and checkboxes are readonly.
