### PR TITLE
typo fixes in developer documentations

### DIFF
--- a/docs/getting_started/install_aiverify_dev_tools.md
+++ b/docs/getting_started/install_aiverify_dev_tools.md
@@ -24,7 +24,7 @@ The Developer Tools require specific modules from the main AI Verify repository.
 1. Clone the required modules and selectively checkout dependencies needed for Developer Tools
 ```bash
 # Execute in the working directory
-git clone git@github.com:IMDA-BTG/aiverify.git # requires Github public SSH key
+git clone https://github.com/IMDA-BTG/aiverify.git
 cd aiverify
 git sparse-checkout init --cone
 git sparse-checkout set ai-verify-shared-library test-engine-core-modules test-engine-core
@@ -130,7 +130,7 @@ git clone https://github.com/IMDA-BTG/aiverify-developer-tools.git
 ```bash
 cd aiverify-developer-tools/ai-verify-plugin
 npm install
-npm install ../../aiverify/ai-verify-shared-library
+npm link ../../aiverify/ai-verify-shared-library
 sudo npm install -g # You may need sudo for this command
 ```
 

--- a/docs/plugins/Plugin_Tool.md
+++ b/docs/plugins/Plugin_Tool.md
@@ -336,4 +336,4 @@ Options:
   --hostname   Playground hostname to listen on                                          [string] [default: "localhost"]
 ```
 
-To start the playground, runs the playground command under a plugin directory. The command will scan for the algorithms, widgets and input blocks found under the plugin and luanches the playground app listening on http://localhost:5000/ by default. To change the port and hostname, use the options to configure.
+To start the playground, runs the playground command under a plugin directory. The command will scan for the algorithms, widgets and input blocks found under the plugin and launches the playground app listening on http://localhost:5000/ by default. To change the port and hostname, use the options to configure.


### PR DESCRIPTION
Fixes for typos in developer documentation

To test, run mkdocs:
- Check ["Installing AI Verify Developer Tools - Before you begin"](https://imda-btg.github.io/aiverify-developer-tools/getting_started/install_aiverify_dev_tools/] and follow through the tutorial)
- Verify that the typo for "launches" on "AI Verify Plugin Tool"(https://imda-btg.github.io/aiverify-developer-tools/plugins/Plugin_Tool/) has been changed